### PR TITLE
Fix/breaking integration tests

### DIFF
--- a/src/CLI/Arguments/Flag.cs
+++ b/src/CLI/Arguments/Flag.cs
@@ -24,7 +24,7 @@ public enum ShortFlagType
     q,
     s,
     c,
-    nc,
+    n,
     r,
     t,
     v,

--- a/src/CLI/Arguments/ParseArguments.cs
+++ b/src/CLI/Arguments/ParseArguments.cs
@@ -129,12 +129,12 @@ public class Parse
             ShortFlagType.q => FlagType.Quiet,
             ShortFlagType.s => FlagType.Sort,
             ShortFlagType.c => FlagType.Contains,
-            ShortFlagType.nc => FlagType.Nocontains,
+            ShortFlagType.n => FlagType.Nocontains,
             ShortFlagType.r => FlagType.Remote,
             ShortFlagType.t => FlagType.Track,
             ShortFlagType.v => FlagType.Version,
             ShortFlagType.p => FlagType.Printtop,
-            _ => FlagType.All
+            _ => throw new NotImplementedException("Short flag not implemented"),
         };
     }
 }

--- a/src/CLI/Output/PrintFullTable.cs
+++ b/src/CLI/Output/PrintFullTable.cs
@@ -26,6 +26,12 @@ public class PrintFullTable
 
         PrintHeaders();
 
+        if (Console.IsOutputRedirected || !Console.IsInputRedirected)
+        {
+            PrintBranchRows(branches, null);
+            return;
+        }
+
         if (branches.Count > ConsoleHeight)
         {
             StartPaging(branches);

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -162,6 +162,36 @@ public partial class IntegrationTest
         Assert.All(branchNames, b => Assert.Contains("main", b, StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task IntegrationTest_ValidOutput_WithNoContainsFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("--no-contains main");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+
+        string[] branchNames = lines.Skip(2).Select(l => l.Split('|')[2].Trim()).ToArray();
+
+        Assert.All(branchNames, b => Assert.DoesNotContain("main", b, StringComparison.OrdinalIgnoreCase));
+    }
+
     private static void AssertHeader(string[] headerLines)
     {
         Assert.True(headerLines.Length >= 2, "Header lines does not contain enought lines for header print.");

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -653,6 +653,18 @@ public partial class IntegrationTest
         Assert.Equal("You cannot use both --all and --remote\n", output);
     }
 
+    [Fact]
+    public async Task IntegrationTest_NotValidOutput_WithPrintTopFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-p", "0");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+        Assert.Equal("Value for --print-top must be greater than 0\n", output);
+    }
     #endregion
 
     private static void AssertHeader(string[] headerLines)

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -627,6 +627,19 @@ public partial class IntegrationTest
         Assert.Equal("You cannot use --version with any other option\n", output);
     }
 
+    [Fact]
+    public async Task IntegrationTest_NotValidOutput_WithContainsAndNoContainsFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-c", "main", "-n", "main");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+        Assert.Equal("You cannot use both --contains and --no-contains\n", output);
+    }
+
     #endregion
 
     private static void AssertHeader(string[] headerLines)

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -192,6 +192,32 @@ public partial class IntegrationTest
         Assert.All(branchNames, b => Assert.DoesNotContain("main", b, StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task IntegrationTest_ValidOutput_WithAllFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("--all");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+    }
+
     private static void AssertHeader(string[] headerLines)
     {
         Assert.True(headerLines.Length >= 2, "Header lines does not contain enought lines for header print.");

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -265,6 +265,26 @@ public partial class IntegrationTest
         Assert.DoesNotContain("Last commit ", lines[0]);
     }
 
+    [Fact]
+    public async Task IntegrationTest_ValidOutput_WithPrintTopFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("--print-top 1");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        Assert.True(lines.Length <= 3, "Too many lines printed.");
+    }
+
     private static void AssertHeader(string[] headerLines)
     {
         Assert.True(headerLines.Length >= 2, "Header lines does not contain enought lines for header print.");

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -132,6 +132,36 @@ public partial class IntegrationTest
         Assert.Equal(branchNames, sortedBranchNames);
     }
 
+    [Fact]
+    public async Task IntegrationTest_ValidOutput_WithContainsFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("--contains main");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+
+        string[] branchNames = lines.Skip(2).Select(l => l.Split('|')[2].Trim()).ToArray();
+
+        Assert.All(branchNames, b => Assert.Contains("main", b, StringComparison.OrdinalIgnoreCase));
+    }
+
     private static void AssertHeader(string[] headerLines)
     {
         Assert.True(headerLines.Length >= 2, "Header lines does not contain enought lines for header print.");

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -100,6 +100,38 @@ public partial class IntegrationTest
         }
     }
 
+    [Fact]
+    public async Task IntegragionTest_ValidOutput_WithSortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("--sort name");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+
+        string[] branchNames = lines.Skip(2).Select(l => l.Split('|')[2].Trim()).ToArray();
+
+        string[] sortedBranchNames = branchNames.OrderBy(b => b).ToArray();
+
+        Assert.Equal(branchNames, sortedBranchNames);
+    }
+
     private static void AssertHeader(string[] headerLines)
     {
         Assert.True(headerLines.Length >= 2, "Header lines does not contain enought lines for header print.");

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -74,6 +74,32 @@ public partial class IntegrationTest
         Assert.True(match.Success, "Failed to match version pattern.");
     }
 
+    [Fact]
+    public async Task IntegrationTest_ValidOutput_WithTrackFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("--track");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+    }
+
     private static void AssertHeader(string[] headerLines)
     {
         Assert.True(headerLines.Length >= 2, "Header lines does not contain enought lines for header print.");

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -218,6 +218,32 @@ public partial class IntegrationTest
         }
     }
 
+    [Fact]
+    public async Task IntegrationTest_ValidOutput_WithRemoteFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("--remote");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+    }
+
     private static void AssertHeader(string[] headerLines)
     {
         Assert.True(headerLines.Length >= 2, "Header lines does not contain enought lines for header print.");

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -244,6 +244,27 @@ public partial class IntegrationTest
         }
     }
 
+    [Fact]
+    public async Task IntegrationTest_ValidOutput_WithQuietFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("--quiet");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.DoesNotContain("Ahead 󰜘", lines[0]);
+        Assert.DoesNotContain("Behind 󰜘", lines[0]);
+        Assert.DoesNotContain("Branch Name ", lines[0]);
+        Assert.DoesNotContain("Last commit ", lines[0]);
+    }
+
     private static void AssertHeader(string[] headerLines)
     {
         Assert.True(headerLines.Length >= 2, "Header lines does not contain enought lines for header print.");

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -31,8 +31,39 @@ public partial class IntegrationTest
         }
     }
 
+    #region HelpFlag
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithHelpFlag()
+    {
+        await IntegrationTest_ValidOutput_WithHelpShortFlag();
+        await IntegrationTest_ValidOutput_WithHelpLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithHelpShortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-h");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Contains("--help,        -h", lines[2]);
+        Assert.Contains("--track,       -t", lines[3]);
+        Assert.Contains("--sort,        -s", lines[4]);
+        Assert.Contains("--contains,    -c", lines[5]);
+        Assert.Contains("--no-contains, -n", lines[6]);
+        Assert.Contains("--all,         -a", lines[7]);
+        Assert.Contains("--remote,      -r", lines[8]);
+        Assert.Contains("--quiet,       -q", lines[9]);
+        Assert.Contains("--print-top,   -p", lines[10]);
+        Assert.Contains("--version,     -v", lines[11]);
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithHelpLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--help");
         process.Start();
@@ -55,11 +86,19 @@ public partial class IntegrationTest
         Assert.Contains("--print-top,   -p", lines[10]);
         Assert.Contains("--version,     -v", lines[11]);
     }
+    #endregion
 
+    #region VersionFlag    
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithVersionFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("--version");
+        await IntegrationTest_ValidOutput_WithVersionShortFlag();
+        await IntegrationTest_ValidOutput_WithVersionLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithVersionShortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-v");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -74,8 +113,58 @@ public partial class IntegrationTest
         Assert.True(match.Success, "Failed to match version pattern.");
     }
 
+    private async Task IntegrationTest_ValidOutput_WithVersionLongFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-v");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        const string pattern = @"v(\d+)\.(\d+)\.(\d+)";
+
+        Match match = Regex.Match(output, pattern);
+
+        Assert.True(match.Success, "Failed to match version pattern.");
+    }
+    #endregion
+
+    #region TrackFlag
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithTrackFlag()
+    {
+        await IntegrationTest_ValidOutput_WithTrackShortFlag();
+        await IntegrationTest_ValidOutput_WithTrackLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithTrackShortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-t main");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithTrackLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--track main");
         process.Start();
@@ -100,8 +189,17 @@ public partial class IntegrationTest
         }
     }
 
+    #endregion
+
+    #region SortFlag
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithSortFlag()
+    {
+        await IntegrationTest_ValidOutput_WithSortShortFlag();
+        await IntegrationTest_ValidOutput_WithSortLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithSortShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--sort name");
         process.Start();
@@ -132,8 +230,77 @@ public partial class IntegrationTest
         Assert.Equal(branchNames, sortedBranchNames);
     }
 
+    private async Task IntegrationTest_ValidOutput_WithSortLongFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("--sort name");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+
+        string[] branchNames = lines.Skip(2).Select(l => l.Split('|')[2].Trim()).ToArray();
+
+        string[] sortedBranchNames = branchNames.OrderBy(b => b).ToArray();
+
+        Assert.Equal(branchNames, sortedBranchNames);
+    }
+
+    #endregion
+
+    #region ContainsFlag
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithContainsFlag()
+    {
+        await IntegrationTest_ValidOutput_WithContainsShortFlag();
+        await IntegrationTest_ValidOutput_WithContainsLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithContainsShortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-c main");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+
+        string[] branchNames = lines.Skip(2).Select(l => l.Split('|')[2].Trim()).ToArray();
+
+        Assert.All(branchNames, b => Assert.Contains("main", b, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithContainsLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--contains main");
         process.Start();
@@ -161,9 +328,46 @@ public partial class IntegrationTest
 
         Assert.All(branchNames, b => Assert.Contains("main", b, StringComparison.OrdinalIgnoreCase));
     }
+    #endregion
 
+    #region NoContainsFlag
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithNoContainsFlag()
+    {
+        await IntegrationTest_ValidOutput_WithNoContainsShortFlag();
+        await IntegrationTest_ValidOutput_WithNoContainsLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithNoContainsShortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-n main");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+
+        string[] branchNames = lines.Skip(2).Select(l => l.Split('|')[2].Trim()).ToArray();
+
+        Assert.All(branchNames, b => Assert.DoesNotContain("main", b, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithNoContainsLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--no-contains main");
         process.Start();
@@ -191,9 +395,42 @@ public partial class IntegrationTest
 
         Assert.All(branchNames, b => Assert.DoesNotContain("main", b, StringComparison.OrdinalIgnoreCase));
     }
+    #endregion
 
+    #region AllFlag
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithAllFlag()
+    {
+        await IntegrationTest_ValidOutput_WithAllShortFlag();
+        await IntegrationTest_ValidOutput_WithAllLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithAllShortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-a");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithAllLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--all");
         process.Start();
@@ -217,9 +454,42 @@ public partial class IntegrationTest
             Assert.True(behind >= 0, "behind was below 0.");
         }
     }
+    #endregion
 
+    #region RemoteFlag
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithRemoteFlag()
+    {
+        await IntegrationTest_ValidOutput_WithRemoteShortFlag();
+        await IntegrationTest_ValidOutput_WithRemoteLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithRemoteShortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-r");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        foreach (string line in lines.Skip(2))
+        {
+            var (ahead, behind) = GetAheadBehindFromString(line);
+
+            Assert.True(ahead >= 0, "ahead was below 0.");
+            Assert.True(behind >= 0, "behind was below 0.");
+        }
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithRemoteLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--remote");
         process.Start();
@@ -244,8 +514,37 @@ public partial class IntegrationTest
         }
     }
 
+    #endregion
+
+    #region QuietFlag
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithQuietFlag()
+    {
+        await IntegrationTest_ValidOutput_WithQuietShortFlag();
+        await IntegrationTest_ValidOutput_WithQuietLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithQuietShortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-q");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.DoesNotContain("Ahead 󰜘", lines[0]);
+        Assert.DoesNotContain("Behind 󰜘", lines[0]);
+        Assert.DoesNotContain("Branch Name ", lines[0]);
+        Assert.DoesNotContain("Last commit ", lines[0]);
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithQuietLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--quiet");
         process.Start();
@@ -265,8 +564,17 @@ public partial class IntegrationTest
         Assert.DoesNotContain("Last commit ", lines[0]);
     }
 
+    #endregion
+
+    #region PrintTopFlag
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithPrintTopFlag()
+    {
+        await IntegrationTest_ValidOutput_WithPrintTopShortFlag();
+        await IntegrationTest_ValidOutput_WithPrintTopLongFlag();
+    }
+
+    private async Task IntegrationTest_ValidOutput_WithPrintTopLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--print-top 1");
         process.Start();
@@ -284,6 +592,26 @@ public partial class IntegrationTest
 
         Assert.True(lines.Length <= 3, "Too many lines printed.");
     }
+
+    private async Task IntegrationTest_ValidOutput_WithPrintTopShortFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-p 1");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        AssertHeader(lines);
+
+        Assert.True(lines.Length <= 3, "Too many lines printed.");
+    }
+    #endregion
 
     private static void AssertHeader(string[] headerLines)
     {

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -39,7 +39,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithHelpLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithHelpShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithHelpShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-h");
         process.Start();
@@ -63,7 +63,7 @@ public partial class IntegrationTest
         Assert.Contains("--version,     -v", lines[11]);
     }
 
-    private async Task IntegrationTest_ValidOutput_WithHelpLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithHelpLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--help");
         process.Start();
@@ -96,7 +96,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithVersionLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithVersionShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithVersionShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-v");
         process.Start();
@@ -113,7 +113,7 @@ public partial class IntegrationTest
         Assert.True(match.Success, "Failed to match version pattern.");
     }
 
-    private async Task IntegrationTest_ValidOutput_WithVersionLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithVersionLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-v");
         process.Start();
@@ -139,7 +139,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithTrackLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithTrackShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithTrackShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-t", "main");
         process.Start();
@@ -164,7 +164,7 @@ public partial class IntegrationTest
         }
     }
 
-    private async Task IntegrationTest_ValidOutput_WithTrackLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithTrackLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--track", "main");
         process.Start();
@@ -199,7 +199,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithSortLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithSortShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithSortShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-s", "name");
         process.Start();
@@ -230,7 +230,7 @@ public partial class IntegrationTest
         Assert.Equal(branchNames, sortedBranchNames);
     }
 
-    private async Task IntegrationTest_ValidOutput_WithSortLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithSortLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--sort", "name");
         process.Start();
@@ -271,7 +271,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithContainsLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithContainsShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithContainsShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-c", "main");
         process.Start();
@@ -300,7 +300,7 @@ public partial class IntegrationTest
         Assert.All(branchNames, b => Assert.Contains("main", b, StringComparison.OrdinalIgnoreCase));
     }
 
-    private async Task IntegrationTest_ValidOutput_WithContainsLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithContainsLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--contains", "main");
         process.Start();
@@ -338,7 +338,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithNoContainsLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithNoContainsShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithNoContainsShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-n", "main");
         process.Start();
@@ -367,7 +367,7 @@ public partial class IntegrationTest
         Assert.All(branchNames, b => Assert.DoesNotContain("main", b, StringComparison.OrdinalIgnoreCase));
     }
 
-    private async Task IntegrationTest_ValidOutput_WithNoContainsLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithNoContainsLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--no-contains", "main");
         process.Start();
@@ -405,7 +405,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithAllLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithAllShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithAllShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-a");
         process.Start();
@@ -430,7 +430,7 @@ public partial class IntegrationTest
         }
     }
 
-    private async Task IntegrationTest_ValidOutput_WithAllLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithAllLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--all");
         process.Start();
@@ -464,7 +464,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithRemoteLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithRemoteShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithRemoteShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-r");
         process.Start();
@@ -489,7 +489,7 @@ public partial class IntegrationTest
         }
     }
 
-    private async Task IntegrationTest_ValidOutput_WithRemoteLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithRemoteLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--remote");
         process.Start();
@@ -524,7 +524,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithQuietLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithQuietShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithQuietShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-q");
         process.Start();
@@ -544,7 +544,7 @@ public partial class IntegrationTest
         Assert.DoesNotContain("Last commit ", lines[0]);
     }
 
-    private async Task IntegrationTest_ValidOutput_WithQuietLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithQuietLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--quiet");
         process.Start();
@@ -574,7 +574,7 @@ public partial class IntegrationTest
         await IntegrationTest_ValidOutput_WithPrintTopLongFlag();
     }
 
-    private async Task IntegrationTest_ValidOutput_WithPrintTopLongFlag()
+    private static async Task IntegrationTest_ValidOutput_WithPrintTopLongFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--print-top", "1");
         process.Start();
@@ -593,7 +593,7 @@ public partial class IntegrationTest
         Assert.True(lines.Length <= 3, "Too many lines printed.");
     }
 
-    private async Task IntegrationTest_ValidOutput_WithPrintTopShortFlag()
+    private static async Task IntegrationTest_ValidOutput_WithPrintTopShortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("-p", "1");
         process.Start();

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -77,7 +77,7 @@ public partial class IntegrationTest
     [Fact]
     public async Task IntegrationTest_ValidOutput_WithTrackFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("--track");
+        using var process = ProcessHelper.GetDotnetProcess("--track main");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -101,7 +101,7 @@ public partial class IntegrationTest
     }
 
     [Fact]
-    public async Task IntegragionTest_ValidOutput_WithSortFlag()
+    public async Task IntegrationTest_ValidOutput_WithSortFlag()
     {
         using var process = ProcessHelper.GetDotnetProcess("--sort name");
         process.Start();

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -640,6 +640,19 @@ public partial class IntegrationTest
         Assert.Equal("You cannot use both --contains and --no-contains\n", output);
     }
 
+    [Fact]
+    public async Task IntegrationTest_NotValidOutput_WithAllAndRemoteFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-a", "-r");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+        Assert.Equal("You cannot use both --all and --remote\n", output);
+    }
+
     #endregion
 
     private static void AssertHeader(string[] headerLines)

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -141,7 +141,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithTrackShortFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("-t main");
+        using var process = ProcessHelper.GetDotnetProcess("-t", "main");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -166,7 +166,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithTrackLongFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("--track main");
+        using var process = ProcessHelper.GetDotnetProcess("--track", "main");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -201,7 +201,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithSortShortFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("--sort name");
+        using var process = ProcessHelper.GetDotnetProcess("-s", "name");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -232,7 +232,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithSortLongFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("--sort name");
+        using var process = ProcessHelper.GetDotnetProcess("--sort", "name");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -273,7 +273,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithContainsShortFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("-c main");
+        using var process = ProcessHelper.GetDotnetProcess("-c", "main");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -302,7 +302,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithContainsLongFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("--contains main");
+        using var process = ProcessHelper.GetDotnetProcess("--contains", "main");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -340,7 +340,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithNoContainsShortFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("-n main");
+        using var process = ProcessHelper.GetDotnetProcess("-n", "main");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -369,7 +369,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithNoContainsLongFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("--no-contains main");
+        using var process = ProcessHelper.GetDotnetProcess("--no-contains", "main");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -576,7 +576,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithPrintTopLongFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("--print-top 1");
+        using var process = ProcessHelper.GetDotnetProcess("--print-top", "1");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -595,7 +595,7 @@ public partial class IntegrationTest
 
     private async Task IntegrationTest_ValidOutput_WithPrintTopShortFlag()
     {
-        using var process = ProcessHelper.GetDotnetProcess("-p 1");
+        using var process = ProcessHelper.GetDotnetProcess("-p", "1");
         process.Start();
 
         string output = await process.StandardOutput.ReadToEndAsync();
@@ -611,6 +611,22 @@ public partial class IntegrationTest
 
         Assert.True(lines.Length <= 3, "Too many lines printed.");
     }
+    #endregion
+
+    #region ValidationArguments
+    [Fact]
+    public async Task IntegrationTest_NotValidOutput_WithVersionAndOtherFlag()
+    {
+        using var process = ProcessHelper.GetDotnetProcess("-v", "-t", "main");
+        process.Start();
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+        Assert.Equal("You cannot use --version with any other option\n", output);
+    }
+
     #endregion
 
     private static void AssertHeader(string[] headerLines)

--- a/tests/IntegrationTests/ProcessHelper.cs
+++ b/tests/IntegrationTests/ProcessHelper.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+
+namespace IntegrationTests;
+
+public class ProcessHelper
+{
+    public static Process GetDotnetProcess(params string[] flags)
+    {
+        string combinedFlags = string.Join(" ", flags);
+
+        string repoPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../../../");
+        Process process = new()
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"run --project ./src/CLI/CLI.csproj -- {combinedFlags}",
+                WorkingDirectory = repoPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        return process;
+    }
+}


### PR DESCRIPTION
This PR fixes the integration tests that broke due to an issue with the `pager view`. The failure occurred because the pager view was attempting to determine the terminal window size, but the tests were run in an environment without a terminal window, causing them to fail.

During the process of writing and debugging these tests, an additional issue was discovered: the `--no-contains` (`-n`) flag triggered an error:

```
Invalid option: n
```

## Changes
- Adjusted the integration tests to handle environments where a terminal window is not present, ensuring the pager view does not cause failures in such cases.
- Fixed the handling of the `--no-contains` (`-n`) flag within the pager view to prevent the "Invalid option" error.

## Issue Reference
Fixes #58 #55 