### PR TITLE
feat: Regex support for --contains and --no-contains

### DIFF
--- a/src/GitService/OptionStrategies/Common/ContainsStrategies/ContainsOption.cs
+++ b/src/GitService/OptionStrategies/Common/ContainsStrategies/ContainsOption.cs
@@ -1,4 +1,5 @@
 using Bbranch.Shared.TableData;
+using System.Text.RegularExpressions;
 
 namespace Bbranch.GitService.OptionStrategies.Common.ContainsStrategies;
 
@@ -8,6 +9,19 @@ public sealed class ContainsOption(string pattern) : IOption
     {
         string[] patterns = ContainsSplit.SplitArgument(pattern);
 
-        return [.. branches.Where(branch => patterns.Any(pattern => branch.Branch.Name.Contains(pattern)))];
+        return
+        [
+            .. branches.Where(branch => patterns.Any(p =>
+            {
+                try
+                {
+                    return Regex.IsMatch(branch.Branch.Name, p, RegexOptions.IgnoreCase);
+                }
+                catch
+                {
+                    return branch.Branch.Name.Contains(p, StringComparison.OrdinalIgnoreCase);
+                }
+            }))
+        ];
     }
 }

--- a/src/GitService/OptionStrategies/Common/ContainsStrategies/NoContainsOption.cs
+++ b/src/GitService/OptionStrategies/Common/ContainsStrategies/NoContainsOption.cs
@@ -1,4 +1,5 @@
 using Bbranch.Shared.TableData;
+using System.Text.RegularExpressions;
 
 namespace Bbranch.GitService.OptionStrategies.Common.ContainsStrategies;
 
@@ -8,6 +9,19 @@ public sealed class NoContainsOption(string pattern) : IOption
     {
         string[] patterns = ContainsSplit.SplitArgument(pattern);
 
-        return [.. branches.Where(branch => patterns.All(pattern => !branch.Branch.Name.Contains(pattern)))];
+        return
+        [
+            .. branches.Where(branch => patterns.All(p =>
+            {
+                try
+                {
+                    return !Regex.IsMatch(branch.Branch.Name, p, RegexOptions.IgnoreCase);
+                }
+                catch
+                {
+                    return !branch.Branch.Name.Contains(p, StringComparison.OrdinalIgnoreCase);
+                }
+            }))
+        ];
     }
 }


### PR DESCRIPTION
Hello, saw regex support in the roadmap and decided to tackle it. Swapped basic string matching for Regex in both contains/no-contains flags. I also added a fallback to plain text search if the regex is invalid, so it doesn't crash on bad input. Checked it locally, works fine.